### PR TITLE
Issue of OpenBookmark not showing files of bookmarked directories that are on other drives

### DIFF
--- a/lua/ezbookmarks/init.lua
+++ b/lua/ezbookmarks/init.lua
@@ -154,7 +154,10 @@ M.OpenBookmark = function(opts)
       if (vim.fn.has("win32") == 0) then
         p = io.popen("find ".. v .." -type f")
       else
-        p = io.popen("cd " .. v .. " && dir /s /b | findstr /m /c:.")
+        -- The double quotes are im important. Without it, the
+        -- dir command does not work with paths that contain
+        -- forward slashes like D:/my-data
+        p = io.popen('dir "' .. v .. '" /s /b /a-d')
       end
       for f in p:lines() do
         local tmp = string.sub(f, #v + 1, #f)


### PR DESCRIPTION
- OS: Windows

- Reproduction step:
    - Bookmark a directory on drive D (e.g. D:\notes)
    - Open neovim with the pwd in C:\
    - OpenBookmark
    - No files in D:\notes are displayed

- Root cause:
    - On Windows, you cannot `cd` to a path that is on another drive.

- Solution:
    - Use `dir <path>` instead of `cd`ing and then `dir`ing the current directory
